### PR TITLE
Fix if html contains selected options

### DIFF
--- a/jquery.mutuallyExclusive.js
+++ b/jquery.mutuallyExclusive.js
@@ -11,11 +11,6 @@
     // Define the plugin function
     var mutuallyExclusive = function(elem) {
 
-        // Right off the bat, store an original copy of all options in each select element
-        $all_selects.each(function() {
-            $(this).data('original_option_list', $(this).find('option'));
-        });
-
         // This function takes care of updating the state of each select element appropriately
         // based on the options selected in the other select elements.
         function updateSelectElements() {
@@ -80,6 +75,10 @@
         $options = $.extend($options, options);
         // Populate the all_selects object
         $all_selects = this;
+        // Right off the bat, store an original copy of all options in each select element
+        $all_selects.each(function() {
+            $(this).data('original_option_list', $(this).find('option'));
+        });
         // Return jQuery for chaining
         return this.each(function() {
             new mutuallyExclusive($(this));

--- a/jquery.mutuallyExclusive.js
+++ b/jquery.mutuallyExclusive.js
@@ -38,7 +38,7 @@
                         .find('option').removeAttr('disabled');
 
                     // Now that we reloaded the original options, lets reselect the option that was previously selected
-                    $select.find('option[value="' + currently_selected_val + '"]').attr("selected", "selected");
+                    $select.val(currently_selected_val);
 
                     // Finally, remove the options that have been selected in the other select elements and we're all set!
                     $siblings_selected_options.each(function() {


### PR DESCRIPTION
I have provided a fix: 

If the html document already contains a selected option
`<option selected="selected">...</option>`
the original_option_list data was not initialized properly. The data must be initialized only once during "jQueryfization" of the selected elements.
